### PR TITLE
Added support for admin saving the object via update_attributes

### DIFF
--- a/lib/application_service.rb
+++ b/lib/application_service.rb
@@ -67,16 +67,16 @@ class ApplicationService
     end
   end
 
-  def update_attributes(obj, params)
+  def update_attributes(obj, params, with_admin_save: false)
     @obj = obj
     @obj.assign_attributes(params)
 
     yield if block_given?
 
-    run_callbacks :save do
-      run_callbacks :update do
-         @obj.save
-      end
+    if with_admin_save
+      self.admin_save(obj)
+    else
+      self.save(obj)
     end
   end
 

--- a/spec/application_service_spec.rb
+++ b/spec/application_service_spec.rb
@@ -71,12 +71,20 @@ describe ApplicationService do
   end
 
   describe "#update_attributes" do
+    let(:obj) { double(new_record?: false) }
+
     it "should trigger update" do
-      obj = double()
       expect(obj).to receive(:assign_attributes).with( {:foo => 'bar'}).and_return(true)
       expect(obj).to receive(:save)
 
       subject.update_attributes(obj, {:foo => 'bar'})
+    end
+
+    it 'should trigger admin_save if argument is true' do
+      expect(obj).to receive(:assign_attributes).with( {:foo => 'bar'}).and_return(true)
+      expect(obj).to receive(:admin_save)
+
+      subject.update_attributes(obj, {:foo => 'bar'}, with_admin_save: true)
     end
   end
 


### PR DESCRIPTION
What says in the tin, invoke `update_attributes` with `with_admin_save = true` to persist the changes using the `admin_save` method on the model if present.